### PR TITLE
Fix release-1gp.yml workflow

### DIFF
--- a/.github/workflows/release-1gp.yml
+++ b/.github/workflows/release-1gp.yml
@@ -54,7 +54,7 @@ jobs:
               if: ${{ inputs.skip-deploy == false }}
               run: cci flow run ci_master --org packaging
             - name: Build Production Package
-              run: cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template '${{ inputs.release-name }}'")
+              run: eval $(echo cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template '${{ inputs.release-name }}'"))
               shell: bash
             - name: Run Release Test in Scratch Org
               if: ${{ inputs.skip-test == false }}

--- a/.github/workflows/release-1gp.yml
+++ b/.github/workflows/release-1gp.yml
@@ -54,7 +54,8 @@ jobs:
               if: ${{ inputs.skip-deploy == false }}
               run: cci flow run ci_master --org packaging
             - name: Build Production Package
-              run: eval $(echo cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template \\"${{ inputs.release-name }}\\"))
+              run: |
+                cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template=\"${{ inputs.release-name }}\"")
               shell: bash
             - name: Run Release Test in Scratch Org
               if: ${{ inputs.skip-test == false }}

--- a/.github/workflows/release-1gp.yml
+++ b/.github/workflows/release-1gp.yml
@@ -49,12 +49,12 @@ jobs:
             - name: Report Inputs
               run: |
                 echo "Release Name: ${{ inputs.release-name }}" | tee -a "${GITHUB_STEP_SUMMARY}"
-                echo 'Command: cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template '${{ inputs.release-name }}'")' | tee -a "${GITHUB_STEP_SUMMARY}"
+                echo 'Command: cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template \\"${{ inputs.release-name }}\\"")' | tee -a "${GITHUB_STEP_SUMMARY}"
             - name: Deploy to Packaging Org
               if: ${{ inputs.skip-deploy == false }}
               run: cci flow run ci_master --org packaging
             - name: Build Production Package
-              run: eval $(echo cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template '${{ inputs.release-name }}'"))
+              run: eval $(echo cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template \\"${{ inputs.release-name }}\\"))
               shell: bash
             - name: Run Release Test in Scratch Org
               if: ${{ inputs.skip-test == false }}


### PR DESCRIPTION
Fix the release name quoting and command evaluation in the `release-1gp.yml` workflow.

* Update the `release-test` job to correctly quote the release name in the command.
* Update the `release-test` job to evaluate the echo of the command into the actual command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muselab-d2x/d2x/tree/cumulusci-next?shareId=5a0ba26c-74de-45a3-b5f2-db7d393b077c).