### PR TITLE
Add missing doc subpages to audiences section

### DIFF
--- a/docs/audiences/enterprise.md
+++ b/docs/audiences/enterprise.md
@@ -1,0 +1,64 @@
+# 🏢 Enterprise Organizations
+
+## Use Cases
+
+### 1. Large-Scale Deployments
+
+Enterprise organizations often manage multiple Salesforce instances across different regions and departments. D2X provides a unified platform to manage these deployments efficiently.
+
+- **Centralized Management**: Manage all Salesforce instances from a single platform.
+- **Automated Deployments**: Use GitHub Actions to automate deployments across multiple instances.
+- **Compliance and Security**: Ensure all deployments meet compliance and security standards.
+
+### 2. Integration with Existing ITSM Systems
+
+Enterprises typically use IT Service Management (ITSM) systems like ServiceNow or Jira. D2X integrates seamlessly with these systems to streamline change management processes.
+
+- **Change Requests**: Automatically create change requests in ITSM systems for deployments.
+- **Approval Workflows**: Integrate approval workflows with ITSM systems.
+- **Audit Trails**: Maintain detailed audit trails for all changes.
+
+### 3. Custom Development and Extensions
+
+Enterprises often require custom development and extensions to meet their unique business needs. D2X supports custom development workflows.
+
+- **Custom Workflows**: Create custom workflows for development and deployment.
+- **Reusable Components**: Build reusable components to speed up development.
+- **Version Control**: Use GitHub for version control and collaboration.
+
+## Value Proposition
+
+### 1. Enhanced Security
+
+D2X leverages GitHub's advanced security features to provide enterprise-grade security.
+
+- **Secret Scanning**: Automatically scan for secrets in your codebase.
+- **Code Scanning**: Identify and fix vulnerabilities in your code.
+- **Dependency Management**: Manage dependencies securely.
+
+### 2. Improved Efficiency
+
+Automate repetitive tasks and streamline workflows to improve efficiency.
+
+- **Automated Testing**: Use GitHub Actions to automate testing.
+- **Continuous Integration**: Implement continuous integration and continuous deployment (CI/CD) pipelines.
+- **Monitoring and Alerts**: Set up monitoring and alerts for deployments.
+
+### 3. Scalability
+
+D2X is designed to scale with your organization.
+
+- **Scalable Architecture**: Built on GitHub's scalable architecture.
+- **Flexible Workflows**: Create flexible workflows to meet your organization's needs.
+- **Global Reach**: Manage deployments across multiple regions and departments.
+
+## Getting Started
+
+To get started with D2X for your enterprise organization, follow these steps:
+
+1. **Set Up GitHub**: Create a GitHub organization and repositories for your Salesforce instances.
+2. **Configure D2X**: Configure D2X to manage your Salesforce instances.
+3. **Integrate ITSM**: Integrate D2X with your existing ITSM systems.
+4. **Automate Workflows**: Create and automate workflows for development, testing, and deployment.
+
+For detailed instructions, refer to the [D2X Documentation](../index.md).

--- a/docs/audiences/index.md
+++ b/docs/audiences/index.md
@@ -67,7 +67,7 @@ The two-stage credential management system provides enterprise-grade security wh
 -   Compliance reporting
 -   Role-based access control
 
-[Learn more about enterprise features](./audiences/enterprise.md)
+[Learn more about enterprise features](./enterprise.md)
 
 ## 📦 ISVs & Package Developers
 
@@ -121,7 +121,9 @@ D2X's composable automation approach means ISVs can build once, reuse everywhere
 -   Standardized security review preparation
 -   Streamlined customer org deployments
 
-[Learn more about ISV features](./audiences/isv.md)
+For ISVs, and potentially for other partners, there's a huge potential to build custom setup UX into their package and trigger GitHub Actions workflows to get an OAuth connection to the target org and run automation with configuration passed via JSON in the UX.
+
+[Learn more about ISV features](./isv.md)
 
 ## 🤝 Consulting Partners
 
@@ -167,7 +169,7 @@ Start with proven patterns and customize for each client's needs:
 -   Client-specific customizations
 -   Knowledge transfer automation
 
-[Learn more about partner features](./audiences/partner.md)
+[Learn more about partner features](./partner.md)
 
 ## 🌱 Small Teams & Nonprofits
 
@@ -213,7 +215,7 @@ D2X grows with your team:
 -   Secure by default
 -   Clear upgrade paths
 
-[Learn more about nonprofit features](./audiences/nonprofit.md)
+[Learn more about nonprofit features](./nonprofit.md)
 
 ## 🎯 Choose Your Path
 

--- a/docs/audiences/isv.md
+++ b/docs/audiences/isv.md
@@ -1,0 +1,64 @@
+# 📦 ISVs & Package Developers
+
+## Use Cases
+
+### 1. Accelerated Package Development
+
+Independent Software Vendors (ISVs) and package developers need to deliver high-quality packages quickly. D2X provides tools and workflows to streamline the development process.
+
+- **Automated Testing**: Use GitHub Actions to automate testing of your packages.
+- **Continuous Integration**: Implement CI/CD pipelines to ensure code quality.
+- **Version Control**: Manage your package versions with GitHub.
+
+### 2. Customer-Specific Customizations
+
+ISVs often need to customize their packages for different customers. D2X supports customer-specific customizations.
+
+- **Forking Repositories**: Create customer-specific forks of your package repository.
+- **Custom Workflows**: Implement custom workflows for different customers.
+- **Automated Deployments**: Use GitHub Actions to automate deployments to customer orgs.
+
+### 3. Security and Compliance
+
+Meeting AppExchange security requirements is crucial for ISVs. D2X helps you meet these requirements.
+
+- **Code Scanning**: Automatically scan your code for vulnerabilities.
+- **Secret Management**: Securely manage secrets and credentials.
+- **Audit Trails**: Maintain detailed audit trails for all changes.
+
+## Value Proposition
+
+### 1. Increased Productivity
+
+D2X automates repetitive tasks, allowing developers to focus on building features.
+
+- **Automated Testing**: Reduce the time spent on manual testing.
+- **Continuous Integration**: Catch issues early with automated CI/CD pipelines.
+- **Reusable Components**: Build reusable components to speed up development.
+
+### 2. Enhanced Security
+
+D2X leverages GitHub's security features to protect your code and data.
+
+- **Secret Scanning**: Automatically scan for secrets in your codebase.
+- **Code Scanning**: Identify and fix vulnerabilities in your code.
+- **Dependency Management**: Manage dependencies securely.
+
+### 3. Improved Customer Satisfaction
+
+Deliver high-quality packages and customizations to your customers quickly and reliably.
+
+- **Automated Deployments**: Ensure consistent deployments to customer orgs.
+- **Custom Workflows**: Tailor workflows to meet customer-specific needs.
+- **Detailed Audit Trails**: Provide customers with detailed audit trails for all changes.
+
+## Getting Started
+
+To get started with D2X for your ISV or package development, follow these steps:
+
+1. **Set Up GitHub**: Create a GitHub organization and repositories for your packages.
+2. **Configure D2X**: Configure D2X to manage your package development and deployments.
+3. **Automate Workflows**: Create and automate workflows for development, testing, and deployment.
+4. **Ensure Security**: Implement security best practices using D2X and GitHub's security features.
+
+For detailed instructions, refer to the [D2X Documentation](../index.md).

--- a/docs/audiences/isv.md
+++ b/docs/audiences/isv.md
@@ -26,6 +26,10 @@ Meeting AppExchange security requirements is crucial for ISVs. D2X helps you mee
 - **Secret Management**: Securely manage secrets and credentials.
 - **Audit Trails**: Maintain detailed audit trails for all changes.
 
+### 4. Custom Setup UX and GitHub Actions Workflows
+
+For ISVs, and potentially for other partners, there's a huge potential to build custom setup UX into their package and trigger GitHub Actions workflows to get an OAuth connection to the target org and run automation with configuration passed via JSON in the UX.
+
 ## Value Proposition
 
 ### 1. Increased Productivity

--- a/docs/audiences/nonprofit.md
+++ b/docs/audiences/nonprofit.md
@@ -1,0 +1,64 @@
+# 🌱 Small Teams & Nonprofits
+
+## Use Cases
+
+### 1. Cost-Effective DevOps
+
+Small teams and nonprofits often operate with limited budgets. D2X provides a cost-effective DevOps solution that leverages GitHub's free offerings for nonprofits.
+
+- **Free GitHub Access**: Utilize GitHub's free plan for nonprofits.
+- **Automated Workflows**: Use GitHub Actions to automate repetitive tasks.
+- **Scalable Solutions**: Start small and scale as needed.
+
+### 2. Simplified Management
+
+Managing Salesforce instances can be complex. D2X simplifies this process for small teams and nonprofits.
+
+- **Centralized Management**: Manage all Salesforce instances from a single platform.
+- **Automated Deployments**: Use GitHub Actions to automate deployments.
+- **Compliance and Security**: Ensure all deployments meet compliance and security standards.
+
+### 3. Pre-Built Integrations
+
+D2X comes with pre-built integrations for common nonprofit use cases, such as the Nonprofit Success Pack (NPSP).
+
+- **NPSP Integration**: Seamlessly integrate with the Nonprofit Success Pack.
+- **Data Management**: Automate data management tasks.
+- **Reporting and Analytics**: Generate reports and analytics to track progress.
+
+## Value Proposition
+
+### 1. Accessibility
+
+D2X makes enterprise-grade DevOps accessible to small teams and nonprofits.
+
+- **Free GitHub Access**: Leverage GitHub's free plan for nonprofits.
+- **User-Friendly Interface**: Easy-to-use interface for managing Salesforce instances.
+- **Community Support**: Access to a community of users and developers.
+
+### 2. Efficiency
+
+Automate repetitive tasks and streamline workflows to improve efficiency.
+
+- **Automated Testing**: Use GitHub Actions to automate testing.
+- **Continuous Integration**: Implement continuous integration and continuous deployment (CI/CD) pipelines.
+- **Monitoring and Alerts**: Set up monitoring and alerts for deployments.
+
+### 3. Scalability
+
+D2X is designed to scale with your organization.
+
+- **Scalable Architecture**: Built on GitHub's scalable architecture.
+- **Flexible Workflows**: Create flexible workflows to meet your organization's needs.
+- **Global Reach**: Manage deployments across multiple regions and departments.
+
+## Getting Started
+
+To get started with D2X for your small team or nonprofit, follow these steps:
+
+1. **Set Up GitHub**: Create a GitHub organization and repositories for your Salesforce instances.
+2. **Configure D2X**: Configure D2X to manage your Salesforce instances.
+3. **Integrate NPSP**: Integrate D2X with the Nonprofit Success Pack (NPSP).
+4. **Automate Workflows**: Create and automate workflows for development, testing, and deployment.
+
+For detailed instructions, refer to the [D2X Documentation](../index.md).

--- a/docs/audiences/partner.md
+++ b/docs/audiences/partner.md
@@ -1,0 +1,64 @@
+# 🤝 Consulting Partners
+
+## Use Cases
+
+### 1. Multi-Client Management
+
+Consulting partners often manage multiple clients with different Salesforce instances. D2X provides a unified platform to manage these clients efficiently.
+
+- **Centralized Management**: Manage all client Salesforce instances from a single platform.
+- **Automated Deployments**: Use GitHub Actions to automate deployments across multiple client instances.
+- **Compliance and Security**: Ensure all deployments meet compliance and security standards.
+
+### 2. Custom Development and Extensions
+
+Consulting partners often require custom development and extensions to meet their clients' unique business needs. D2X supports custom development workflows.
+
+- **Custom Workflows**: Create custom workflows for development and deployment.
+- **Reusable Components**: Build reusable components to speed up development.
+- **Version Control**: Use GitHub for version control and collaboration.
+
+### 3. Integration with Client Systems
+
+Consulting partners typically need to integrate with their clients' existing systems. D2X integrates seamlessly with these systems to streamline processes.
+
+- **Change Requests**: Automatically create change requests in client systems for deployments.
+- **Approval Workflows**: Integrate approval workflows with client systems.
+- **Audit Trails**: Maintain detailed audit trails for all changes.
+
+## Value Proposition
+
+### 1. Enhanced Security
+
+D2X leverages GitHub's advanced security features to provide enterprise-grade security.
+
+- **Secret Scanning**: Automatically scan for secrets in your codebase.
+- **Code Scanning**: Identify and fix vulnerabilities in your code.
+- **Dependency Management**: Manage dependencies securely.
+
+### 2. Improved Efficiency
+
+Automate repetitive tasks and streamline workflows to improve efficiency.
+
+- **Automated Testing**: Use GitHub Actions to automate testing.
+- **Continuous Integration**: Implement continuous integration and continuous deployment (CI/CD) pipelines.
+- **Monitoring and Alerts**: Set up monitoring and alerts for deployments.
+
+### 3. Scalability
+
+D2X is designed to scale with your organization.
+
+- **Scalable Architecture**: Built on GitHub's scalable architecture.
+- **Flexible Workflows**: Create flexible workflows to meet your organization's needs.
+- **Global Reach**: Manage deployments across multiple regions and departments.
+
+## Getting Started
+
+To get started with D2X for your consulting practice, follow these steps:
+
+1. **Set Up GitHub**: Create a GitHub organization and repositories for your clients' Salesforce instances.
+2. **Configure D2X**: Configure D2X to manage your clients' Salesforce instances.
+3. **Integrate Client Systems**: Integrate D2X with your clients' existing systems.
+4. **Automate Workflows**: Create and automate workflows for development, testing, and deployment.
+
+For detailed instructions, refer to the [D2X Documentation](../index.md).


### PR DESCRIPTION
Add detailed subpages to the audiences section in the documentation to expand on the use case and value proposition for each audience, maintaining consistent style with other docs.

* **Enterprise Organizations**: Add `docs/audiences/enterprise.md` detailing use cases and value propositions for enterprise organizations, including large-scale deployments, integration with ITSM systems, and custom development.
* **ISVs & Package Developers**: Add `docs/audiences/isv.md` detailing use cases and value propositions for ISVs and package developers, including accelerated package development, customer-specific customizations, and security and compliance.
* **Consulting Partners**: Add `docs/audiences/partner.md` detailing use cases and value propositions for consulting partners, including multi-client management, custom development, and integration with client systems.
* **Small Teams & Nonprofits**: Add `docs/audiences/nonprofit.md` detailing use cases and value propositions for small teams and nonprofits, including cost-effective DevOps, simplified management, and pre-built integrations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muselab-d2x/d2x?shareId=5ddc8609-4fcb-4808-8776-c4f939160bb0).