### PR TITLE
Add mkdocs-mermaid2-plugin to requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs==1.6.1
 mkdocs_material==9.5.42
+mkdocs-mermaid2-plugin==0.5.2


### PR DESCRIPTION
Add `mkdocs-mermaid2-plugin` to the list of requirements in `docs/requirements.txt`.

* Add `mkdocs-mermaid2-plugin==0.5.2` to `docs/requirements.txt` to resolve the missing plugin error during the build process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muselab-d2x/d2x?shareId=4d9617c3-ff28-473e-a338-dec626966bdc).