### PR TITLE
Fix release name quotation in Salesforce

### DIFF
--- a/.github/workflows/release-1gp.yml
+++ b/.github/workflows/release-1gp.yml
@@ -49,13 +49,13 @@ jobs:
             - name: Report Inputs
               run: |
                 echo "Release Name: ${{ inputs.release-name }}" | tee -a "${GITHUB_STEP_SUMMARY}"
-                echo 'Command: cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template \\"${{ inputs.release-name }}\\"")' | tee -a "${GITHUB_STEP_SUMMARY}"
+                echo 'Command: cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template \${{ inputs.release-name }}")' | tee -a "${GITHUB_STEP_SUMMARY}"
             - name: Deploy to Packaging Org
               if: ${{ inputs.skip-deploy == false }}
               run: cci flow run ci_master --org packaging
             - name: Build Production Package
               run: |
-                cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template \"${{ inputs.release-name }}\"")
+                cci flow run release_production --org packaging $([[ "${{ inputs.release-name }}" ]] && echo " -o upload_production__version_name_template ${{ inputs.release-name }}")
               shell: bash
             - name: Run Release Test in Scratch Org
               if: ${{ inputs.skip-test == false }}


### PR DESCRIPTION
Update the `cci flow run release_production` command to remove double quotes around the release name in `.github/workflows/release-1gp.yml`.

* **Command Update**
  - Modify the `cci flow run release_production` command to remove double quotes around the release name.
  - Update the `version_name_template` parameter to remove double quotes around the release name.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muselab-d2x/d2x/tree/cumulusci-next?shareId=f82654df-78c8-4766-87b8-73630c0ce00f).