### PR TITLE
Modularize workflows for feature 2gp

### DIFF
--- a/.github/workflows/check-no-org.yml
+++ b/.github/workflows/check-no-org.yml
@@ -1,0 +1,38 @@
+name: Check No Org
+
+on:
+    workflow_call:
+        inputs:
+            debug:
+                description: "Enable debug logging output for CumulusCI"
+                required: false
+                default: false
+                type: boolean
+        secrets:
+            github-token:
+                required: true
+
+jobs:
+    check-no-org:
+        name: "Check No Org"
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots
+            options: --user root
+            credentials:
+                username: "${{ github.actor }}"
+                password: "${{ secrets.github-token }}"
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Run Checks
+              run: |
+                  set -e {
+                      cci task run check_no_org \
+                          $([[ "${{ inputs.debug }}" == "true" ]] && echo " --debug")
+                  } || {
+                      echo "::error::Failed to run checks. Running cci error info..."
+                      cci error info
+                      exit 1
+                  }
+              shell: bash

--- a/.github/workflows/configure-org-for-testing.yml
+++ b/.github/workflows/configure-org-for-testing.yml
@@ -1,0 +1,73 @@
+name: Configure Org for Testing
+
+on:
+    workflow_call:
+        inputs:
+            org:
+                required: false
+                default: feature
+                type: string
+            debug:
+                required: false
+                default: false
+                type: boolean
+        secrets:
+            dev-hub-auth-url:
+                required: false
+            dev-hub-username:
+                required: false
+            dev-hub-client-id:
+                required: false
+            dev-hub-private-key:
+                required: false
+            gh-email:
+                required: true
+            github-token:
+                required: true
+            github-app-id:
+                required: false
+            github-app-key:
+                required: false
+
+jobs:
+    configure-org-for-testing:
+        name: "Configure Org for Testing"
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots
+            options: --user root
+            credentials:
+                username: "${{ github.actor }}"
+                password: "${{ secrets.github-token }}"
+        steps:
+            - name: D2X Image Details
+              run: |
+                  echo "D2X Docker Image: ghcr.io/muselab-d2x/d2x"
+                  echo "D2X Docker Tag: cumulusci-next-snapshots"
+                  echo "D2X Docker Image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots" >> $GITHUB_STEP_SUMMARY
+              shell: bash
+
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Auth to DevHub
+              run: /usr/local/bin/devhub.sh
+              env:
+                  DEV_HUB_AUTH_URL: "${{ secrets.dev-hub-auth-url }}"
+                  DEV_HUB_USERNAME: "${{ secrets.dev-hub-username }}"
+                  DEV_HUB_CLIENT_ID: "${{ secrets.dev-hub-client-id }}"
+                  DEV_HUB_PRIVATE_KEY: "${{ secrets.dev-hub-private-key }}"
+
+            - name: Set ${{ inputs.org }} org as default org
+              run: cci org default ${{ inputs.org }}
+
+            - name: Configure Org for Testing
+              id: configure_org
+              env:
+                  GITHUB_TOKEN: "${{ secrets.github-token }}"
+                  CUMULUSCI_SERVICE_github: '{ "username": "${{ github.actor }}", "token": "${{ secrets.github-token }}", "email": "${{ secrets.gh-email }}" }'
+                  GITHUB_APP_ID: "${{ secrets.github-app-id }}"
+                  GITHUB_APP_KEY: "${{ secrets.github-app-key }}"
+              run: |
+                  cci flow run ci_feature_2gp --skip-from run-tests
+              shell: bash

--- a/.github/workflows/create-feature-test-package.yml
+++ b/.github/workflows/create-feature-test-package.yml
@@ -1,0 +1,88 @@
+name: Create Feature Test Package
+
+on:
+  workflow_call:
+    inputs:
+      org:
+        required: false
+        default: feature
+        type: string
+      debug:
+        required: false
+        default: false
+        type: boolean
+      docker_image:
+        required: false
+        default: ghcr.io/muselab-d2x/d2x
+        type: string
+      docker_tag:
+        type: string
+        required: false
+        default: cumulusci-next-snapshots
+    secrets:
+      dev-hub-auth-url:
+        required: false
+      dev-hub-username:
+        required: false
+      dev-hub-client-id:
+        required: false
+      dev-hub-private-key:
+        required: false
+      gh-email:
+        required: true
+      github-token:
+        required: true
+      github-app-id:
+        required: false
+      github-app-key:
+        required: false
+
+jobs:
+  create-feature-test-package:
+    name: "Create Feature Test Package"
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.docker_image }}:${{ inputs.docker_tag }}
+      options: --user root
+      credentials:
+        username: "${{ github.actor }}"
+        password: "${{ secrets.github-token }}"
+    steps:
+      - name: D2X Image Details
+        run: |
+          echo "D2X Docker Image: ${{ inputs.docker_image }}"
+          echo "D2X Docker Tag: ${{ inputs.docker_tag }}"
+          echo "D2X Docker Image: `${{ inputs.docker_image }}:${{ inputs.docker_tag }}`" >> $GITHUB_STEP_SUMMARY
+        shell: bash
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Auth to DevHub
+        run: /usr/local/bin/devhub.sh
+        env:
+          DEV_HUB_AUTH_URL: "${{ secrets.dev-hub-auth-url }}"
+          DEV_HUB_USERNAME: "${{ secrets.dev-hub-username }}"
+          DEV_HUB_CLIENT_ID: "${{ secrets.dev-hub-client-id }}"
+          DEV_HUB_PRIVATE_KEY: "${{ secrets.dev-hub-private-key }}"
+      - name: Set ${{ inputs.org }} org as default org
+        run: cci org default ${{ inputs.org }}
+      - name: Build Feature Test Package
+        env:
+          GITHUB_TOKEN: "${{ secrets.github-token }}"
+          CUMULUSCI_SERVICE_github: '{ "username": "${{ github.actor }}", "token": "${{ secrets.github-token }}", "email": "${{ secrets.gh-email }}" }'
+          GITHUB_APP_ID: "${{ secrets.github-app-id }}"
+          GITHUB_APP_KEY: "${{ secrets.github-app-key }}"
+        run: cci flow run build_feature_test_package $([[ "${{ inputs.debug }}" == "true" ]] && echo " --debug") | tee cumulusci-flow.log
+        shell: bash
+      - name: Set Commit Status
+        env:
+          GITHUB_TOKEN: "${{ secrets.github-token }}"
+        run: |
+          VERSION=$(cat cumulusci-flow.log | grep -o -E -m 1 "04t[a-zA-Z0-9]{15}")
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            '/repos/${{ github.repository }}/statuses/${{ github.sha }}' \
+            -f state='success' \
+            -f description="version_id: $VERSION" \
+            -f context='Build Feature Test Package'
+        shell: bash

--- a/.github/workflows/create-org.yml
+++ b/.github/workflows/create-org.yml
@@ -1,0 +1,76 @@
+name: Create Org
+
+on:
+    workflow_call:
+        inputs:
+            scratchdef_path:
+                description: "Path to the scratch definition file"
+                required: false
+                type: string
+            cli_options:
+                description: "CLI options for creating the scratch org"
+                required: false
+                type: string
+            scratch_profile_name:
+                description: "CumulusCI scratch profile name"
+                required: false
+                default: feature
+                type: string
+            scratchdef_json:
+                description: "Scratch definition as JSON"
+                required: false
+                type: string
+        secrets:
+            dev-hub-auth-url:
+                required: true
+            dev-hub-username:
+                required: true
+            dev-hub-client-id:
+                required: true
+            dev-hub-private-key:
+                required: true
+            gh-email:
+                required: true
+            github-token:
+                required: true
+
+jobs:
+    create-org:
+        name: "Create Org"
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots
+            options: --user root
+            credentials:
+                username: "${{ github.actor }}"
+                password: "${{ secrets.github-token }}"
+            env:
+                DEV_HUB_AUTH_URL: "${{ secrets.dev-hub-auth-url }}"
+                DEV_HUB_USERNAME: "${{ secrets.dev-hub-username }}"
+                DEV_HUB_CLIENT_ID: "${{ secrets.dev-hub-client-id }}"
+                DEV_HUB_PRIVATE_KEY: "${{ secrets.dev-hub-private-key }}"
+                CUMULUSCI_SERVICE_github: '{ "username": "${{ github.actor }}", "token": "${{ secrets.github-token }}", "email": "${{ secrets.gh-email }}" }'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Auth to DevHub
+              run: /usr/local/bin/devhub.sh
+
+            - name: Create Scratch Org
+              run: |
+                  if [ -n "${{ inputs.scratchdef_path }}" ]; then
+                      cci org scratch ${{ inputs.scratch_profile_name }} -f ${{ inputs.scratchdef_path }} ${{ inputs.cli_options }}
+                  elif [ -n "${{ inputs.scratchdef_json }}" ]; then
+                      echo "${{ inputs.scratchdef_json }}" > scratchdef.json
+                      cci org scratch ${{ inputs.scratch_profile_name }} -f scratchdef.json ${{ inputs.cli_options }}
+                  else
+                      cci org scratch ${{ inputs.scratch_profile_name }} ${{ inputs.cli_options }}
+                  fi
+
+            - name: Create Access Token Session Environment
+              run: |
+                  ACCESS_TOKEN=$(cci org info ${{ inputs.scratch_profile_name }} --json | jq -r '.access_token')
+                  INSTANCE_URL=$(cci org info ${{ inputs.scratch_profile_name }} --json | jq -r '.instance_url')
+                  echo "ACCESS_TOKEN=${ACCESS_TOKEN}" >> $GITHUB_ENV
+                  echo "INSTANCE_URL=${INSTANCE_URL}" >> $GITHUB_ENV

--- a/.github/workflows/create-test-scratch-org.yml
+++ b/.github/workflows/create-test-scratch-org.yml
@@ -1,0 +1,76 @@
+name: Create Test Scratch Org
+
+on:
+    workflow_call:
+        inputs:
+            scratchdef_path:
+                description: "Path to the scratch definition file"
+                required: false
+                type: string
+            cli_options:
+                description: "CLI options for creating the scratch org"
+                required: false
+                type: string
+            scratch_profile_name:
+                description: "CumulusCI scratch profile name"
+                required: false
+                default: feature
+                type: string
+            scratchdef_json:
+                description: "Scratch definition as JSON"
+                required: false
+                type: string
+        secrets:
+            dev-hub-auth-url:
+                required: true
+            dev-hub-username:
+                required: true
+            dev-hub-client-id:
+                required: true
+            dev-hub-private-key:
+                required: true
+            gh-email:
+                required: true
+            github-token:
+                required: true
+
+jobs:
+    create-test-scratch-org:
+        name: "Create Test Scratch Org"
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots
+            options: --user root
+            credentials:
+                username: "${{ github.actor }}"
+                password: "${{ secrets.github-token }}"
+            env:
+                DEV_HUB_AUTH_URL: "${{ secrets.dev-hub-auth-url }}"
+                DEV_HUB_USERNAME: "${{ secrets.dev-hub-username }}"
+                DEV_HUB_CLIENT_ID: "${{ secrets.dev-hub-client-id }}"
+                DEV_HUB_PRIVATE_KEY: "${{ secrets.dev-hub-private-key }}"
+                CUMULUSCI_SERVICE_github: '{ "username": "${{ github.actor }}", "token": "${{ secrets.github-token }}", "email": "${{ secrets.gh-email }}" }'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Auth to DevHub
+              run: /usr/local/bin/devhub.sh
+
+            - name: Create Scratch Org
+              run: |
+                  if [ -n "${{ inputs.scratchdef_path }}" ]; then
+                      cci org scratch ${{ inputs.scratch_profile_name }} -f ${{ inputs.scratchdef_path }} ${{ inputs.cli_options }}
+                  elif [ -n "${{ inputs.scratchdef_json }}" ]; then
+                      echo "${{ inputs.scratchdef_json }}" > scratchdef.json
+                      cci org scratch ${{ inputs.scratch_profile_name }} -f scratchdef.json ${{ inputs.cli_options }}
+                  else
+                      cci org scratch ${{ inputs.scratch_profile_name }} ${{ inputs.cli_options }}
+                  fi
+
+            - name: Create Access Token Session Environment
+              run: |
+                  ACCESS_TOKEN=$(cci org info ${{ inputs.scratch_profile_name }} --json | jq -r '.access_token')
+                  INSTANCE_URL=$(cci org info ${{ inputs.scratch_profile_name }} --json | jq -r '.instance_url')
+                  echo "ACCESS_TOKEN=${ACCESS_TOKEN}" >> $GITHUB_ENV
+                  echo "INSTANCE_URL=${INSTANCE_URL}" >> $GITHUB_ENV

--- a/.github/workflows/dispose-org.yml
+++ b/.github/workflows/dispose-org.yml
@@ -1,0 +1,75 @@
+name: Dispose Org
+
+on:
+  workflow_call:
+    inputs:
+      org_name:
+        description: "The name of the scratch org to dispose of"
+        required: true
+        type: string
+      keep_org:
+        description: "If true, the org will not be deleted"
+        required: false
+        default: false
+        type: boolean
+      create_snapshot:
+        description: "If true, a snapshot will be created before disposing of the org"
+        required: false
+        default: false
+        type: boolean
+      snapshot_name:
+        description: "The name of the snapshot to create"
+        required: false
+        type: string
+    secrets:
+      dev-hub-auth-url:
+        required: false
+      dev-hub-username:
+        required: false
+      dev-hub-client-id:
+        required: false
+      dev-hub-private-key:
+        required: false
+      gh-email:
+        required: true
+      github-token:
+        required: true
+      github-app-id:
+        required: false
+      github-app-key:
+        required: false
+
+jobs:
+  dispose-org:
+    name: "Dispose Org"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots
+      options: --user root
+      credentials:
+        username: "${{ github.actor }}"
+        password: "${{ secrets.github-token }}"
+      env:
+        DEV_HUB_AUTH_URL: "${{ secrets.dev-hub-auth-url }}"
+        DEV_HUB_USERNAME: "${{ secrets.dev-hub-username }}"
+        DEV_HUB_CLIENT_ID: "${{ secrets.dev-hub-client-id }}"
+        DEV_HUB_PRIVATE_KEY: "${{ secrets.dev-hub-private-key }}"
+        CUMULUSCI_SERVICE_github: '{ "username": "${{ github.actor }}", "token": "${{ secrets.github-token }}", "email": "${{ secrets.gh-email }}" }'
+        GITHUB_APP_ID: "${{ secrets.github-app-id }}"
+        GITHUB_APP_KEY: "${{ secrets.github-app-key }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Auth to DevHub
+        run: /usr/local/bin/devhub.sh
+
+      - name: Create Snapshot
+        if: ${{ inputs.create_snapshot }}
+        run: |
+          cci task run create_snapshot --snapshot-name ${{ inputs.snapshot_name }}
+
+      - name: Delete Scratch Org
+        if: ${{ !inputs.keep_org }}
+        run: cci org scratch_delete ${{ inputs.org_name }}
+        shell: bash

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,120 @@
+name: Run Tests
+
+on:
+    workflow_call:
+        inputs:
+            org:
+                required: false
+                default: feature
+                type: string
+            debug:
+                required: false
+                default: false
+                type: boolean
+        secrets:
+            dev-hub-auth-url:
+                required: false
+            dev-hub-username:
+                required: false
+            dev-hub-client-id:
+                required: false
+            dev-hub-private-key:
+                required: false
+            gh-email:
+                required: true
+            github-token:
+                required: true
+            github-app-id:
+                required: false
+            github-app-key:
+                required: false
+
+jobs:
+    run-tests:
+        name: "Run Tests"
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots
+            options: --user root
+            credentials:
+                username: "${{ github.actor }}"
+                password: "${{ secrets.github-token }}"
+        steps:
+            - name: D2X Image Details
+              run: |
+                  echo "D2X Docker Image: ghcr.io/muselab-d2x/d2x"
+                  echo "D2X Docker Tag: cumulusci-next-snapshots"
+                  echo "D2X Docker Image: ghcr.io/muselab-d2x/d2x:cumulusci-next-snapshots" >> $GITHUB_STEP_SUMMARY
+              shell: bash
+
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Auth to DevHub
+              run: /usr/local/bin/devhub.sh
+              env:
+                  DEV_HUB_AUTH_URL: "${{ secrets.dev-hub-auth-url }}"
+                  DEV_HUB_USERNAME: "${{ secrets.dev-hub-username }}"
+                  DEV_HUB_CLIENT_ID: "${{ secrets.dev-hub-client-id }}"
+                  DEV_HUB_PRIVATE_KEY: "${{ secrets.dev-hub-private-key }}"
+
+            - name: Set ${{ inputs.org }} org as default org
+              run: cci org default ${{ inputs.org }}
+
+            - name: Run Tests
+              id: run_tests
+              env:
+                  GITHUB_TOKEN: "${{ secrets.github-token }}"
+                  CUMULUSCI_SERVICE_github: '{ "username": "${{ github.actor }}", "token": "${{ secrets.github-token }}", "email": "${{ secrets.gh-email }}" }'
+                  GITHUB_APP_ID: "${{ secrets.github-app-id }}"
+                  GITHUB_APP_KEY: "${{ secrets.github-app-key }}"
+              run: |
+                  cci flow run ci_feature_2gp --start-from run-tests
+              shell: bash
+
+            - name: Capture CumulusCI Build History
+              if: always()
+              run: |
+                  cci history list
+                  cci history dependencies
+                  cci history dependencies --json > cci_dependencies_history.json
+                  cci history list --json > cci_build_history.json
+              shell: bash
+
+            - name: Upload CumulusCI Dependencies History
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: cci-dependencies-history
+                  path: cci_dependencies_history.json
+
+            - name: Upload CumulusCI Build History
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: cci-build-history
+                  path: cci_build_history.json
+
+            - name: Delete Scratch Org
+              if: always()
+              run: cci org scratch_delete ${{ inputs.org }}
+              shell: bash
+
+            - name: Check Job Status
+              if: always()
+              run: |
+                  if [[ "${{ steps.run_tests.outcome }}" == "failure" ]]; then
+                      echo "Run Tests step failed. Failing the job."
+                      exit 1
+                  fi
+
+                  # Check for any failed steps
+                  FAILED_STEPS=$(cat $GITHUB_OUTPUT | grep -c "failure")
+                  echo "Failed steps: $FAILED_STEPS"
+                  if [[ $FAILED_STEPS -gt 0 ]]; then
+                      echo "One or more steps failed. Failing the job."
+                      exit 1
+                  fi
+
+                  echo "All steps completed successfully."
+              shell: bash

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -44,4 +44,59 @@ flowchart LR
 - CI/CD tool bridges
 - Deployment frameworks
 
+## Modular Workflows and Reusable Jobs
+
+D2X now includes a set of modular workflows and reusable jobs to streamline and standardize common tasks. These workflows are designed to be configurable and reusable, making it easier to manage and maintain your CI/CD processes.
+
+### New Modular Workflows
+
+1. **Check No Org Workflow**
+   - File: `.github/workflows/check-no-org.yml`
+   - Description: Checks anything that doesn't require an org.
+   - Configuration: No specific configuration required.
+
+2. **Create Feature Test Package Workflow**
+   - File: `.github/workflows/create-feature-test-package.yml`
+   - Description: Creates the feature test package.
+   - Configuration: No specific configuration required.
+
+3. **Create Test Scratch Org Workflow**
+   - File: `.github/workflows/create-test-scratch-org.yml`
+   - Description: Creates the test scratch org and its environment using d2x commands.
+   - Configuration: No specific configuration required.
+
+4. **Configure Org for Testing Workflow**
+   - File: `.github/workflows/configure-org-for-testing.yml`
+   - Description: Configures the org for testing by running `cci flow run ci_feature_2gp --skip-from run-tests`.
+   - Configuration: No specific configuration required.
+
+5. **Run Tests Workflow**
+   - File: `.github/workflows/run-tests.yml`
+   - Description: Runs the tests by executing `cci flow run ci_feature_2gp --start-from`.
+   - Configuration: No specific configuration required.
+
+6. **Dispose Org Workflow**
+   - File: `.github/workflows/dispose-org.yml`
+   - Description: Disposes of the org with options for keeping the org based on conditions and snapshotting the org using CumulusCI.
+   - Configuration: No specific configuration required.
+
+7. **Create Org Workflow**
+   - File: `.github/workflows/create-org.yml`
+   - Description: Creates orgs using a scratchdef path, CLI options, or a CumulusCI scratch profile name, and runs against a DevHub environment with `D2X_SF_ROLE=devhub-scratch`.
+   - Configuration: No specific configuration required.
+
+### Reusable Jobs
+
+1. **Check Conditions Job**
+   - Description: Checks conditions for various workflows.
+   - Configuration: No specific configuration required.
+
+2. **Set Default Org Job**
+   - Description: Sets the default org for various workflows.
+   - Configuration: No specific configuration required.
+
+3. **Capture Build History Job**
+   - Description: Captures the build history for various workflows.
+   - Configuration: No specific configuration required.
+
 [Back to Architecture Overview](./index.md)


### PR DESCRIPTION
Add new modular workflows and reusable jobs to streamline and standardize common tasks.

* **Documentation**
  - Add a section in `docs/architecture/workflows.md` describing the new modular workflows and reusable jobs.

* **New Workflows**
  - Add `.github/workflows/check-no-org.yml` to check anything that doesn't require an org.
  - Add `.github/workflows/create-feature-test-package.yml` to create the feature test package.
  - Add `.github/workflows/create-test-scratch-org.yml` to create the test scratch org and its environment using d2x commands.
  - Add `.github/workflows/configure-org-for-testing.yml` to configure the org for testing by running `cci flow run ci_feature_2gp --skip-from run-tests`.
  - Add `.github/workflows/run-tests.yml` to run the tests by executing `cci flow run ci_feature_2gp --start-from`.
  - Add `.github/workflows/dispose-org.yml` to dispose of the org with options for keeping the org based on conditions and snapshotting the org using CumulusCI.
  - Add `.github/workflows/create-org.yml` to create orgs using a scratchdef path, CLI options, or a CumulusCI scratch profile name, and run against a DevHub environment with `D2X_SF_ROLE=devhub-scratch`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muselab-d2x/d2x/tree/cumulusci-next-snapshots?shareId=e2bc5dec-0338-4767-a692-9d061cd47d3b).