### PR TITLE
Suggested Changes To Support Access To Test Results By Downstream Consumers

### DIFF
--- a/.github/workflows/feature-test-2gp.yml
+++ b/.github/workflows/feature-test-2gp.yml
@@ -68,6 +68,16 @@ jobs:
               env:
                   GITHUB_TOKEN: '${{ secrets.github-token }}'
               run: cci flow run ci_feature_2gp
+            - name: Upload Apex test results
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                name: apex-test-results
+                path: |
+                  test_results.json
+                  test_results.xml
+                if-no-files-found: warn
+                retention-days: 7
             - name: Delete Scratch Org
               if: ${{ always() }}
               run: |


### PR DESCRIPTION
- The ci_feature_2gp flow runs run_tests, which produces test_results.json and test_results.xml by default
- These files are currently lost when the job completes — no downstream consumers can access them
- Uploading them as artifacts enables consuming workflows (via workflow_run trigger) to download and report on results (e.g., PR comments, badge generation)
- retention-days: 7 keeps storage costs minimal
- if-no-files-found: warn avoids failing the job if tests were skipped


Another alternative would be to create a custom fork of this flow and modify it, is this what you would recommend or is the above a reasonable approach?